### PR TITLE
Ch06 Rename : ensure a boolean to find the correct hero in the list.

### DIFF
--- a/ch06/src/app/heroes/hero-list/hero-list.component.ts
+++ b/ch06/src/app/heroes/hero-list/hero-list.component.ts
@@ -25,7 +25,7 @@ export class HeroListComponent implements OnInit {
     const existingHero = { id: hero.id, name: 'Pricezog' };
 
     this.heroService.editHero(hero.id, existingHero).subscribe(() => {
-      this.heroes.find(hero => hero.id).name = 'Pricezog';
+      this.heroes.find(hero => hero.id == existingHero.id).name = 'Pricezog';
     });
   }
 


### PR DESCRIPTION
When experimenting with the hero list in ch06, I noticed that the rename button only worked when targeting the heroes[0]. If I modified that to heroes[2], it still renames heroes[0]. 

The problem was that the find method wants a boolean function and instead it was only returning hero.id. Since heroes[0] has id = 1, that counts as true and heroes[0] is renamed regardless of whether the id matches.  